### PR TITLE
expose_stash() warning message edits

### DIFF
--- a/lib/Catalyst/View/JSON.pm
+++ b/lib/Catalyst/View/JSON.pm
@@ -68,6 +68,7 @@ sub process {
             $single_key = $expose;
         } else {
             $c->log->warn("expose_stash should be an array reference, Regexp object, or key for a single stash entry.");
+            $c->log->warn("Returning all stash entries");
         }
     }
 

--- a/lib/Catalyst/View/JSON.pm
+++ b/lib/Catalyst/View/JSON.pm
@@ -67,7 +67,7 @@ sub process {
         } elsif (!ref($expose)) {
             $single_key = $expose;
         } else {
-            $c->log->warn("expose_stash should be an array referernce or Regexp object.");
+            $c->log->warn("expose_stash should be an array reference, Regexp object, or key for a single stash entry.");
         }
     }
 

--- a/t/01_server.t
+++ b/t/01_server.t
@@ -9,7 +9,7 @@ use Test::More;
 use Catalyst::Test 'TestApp';
 use JSON::MaybeXS 1.003000 ':legacy';
 
-plan tests => 40;
+plan tests => 47;
 
 BEGIN {
     no warnings 'redefine';
@@ -154,4 +154,16 @@ my $entrypoint = "http://localhost/foo";
     is $data->{foo}, "fake";
 }
 
+{
+    my $request = HTTP::Request->new( GET => "http://localhost/warnmsg" );
 
+    ok( my $response = request($request), 'Request' );
+    ok( $response->is_success, 'Response Successful 2xx' );
+    is( $response->code, 200, 'Response Code' );
+    is_deeply( [ $response->content_type ], [ 'application/json', 'charset=utf-8' ] );
+
+    my $data = from_json($response->content);
+    is $data->{json_foo}, "bar";
+    is_deeply $data->{json_baz}, [ 1, 2, 3 ];
+    is $data->{'foo'}, 'barbarbar';
+}

--- a/t/lib/TestApp/Controller/Root.pm
+++ b/t/lib/TestApp/Controller/Root.pm
@@ -18,6 +18,21 @@ sub foo : Global {
     $c->forward('View::JSON');
 }
 
+sub warnmsg : Global {
+    my ( $self, $c ) = @_;
+
+    # case where setting expose_stash returns everything in
+    # the stash.  Set a true value to enter to code path
+    # that shows the warning message.
+    $c->component('View::JSON')->expose_stash(\1);
+    $c->stash->{json_foo} = "bar";
+    $c->stash->{json_baz} = [ 1, 2, 3 ];
+    $c->stash->{foo}      = "barbarbar";
+
+    $c->forward('View::JSON');
+}
+
+
 sub foo2 : Global {
     my( $self, $c ) = @_;
 


### PR DESCRIPTION
Fix a typo and add second warning that all stash entries are returned (default behaviour).
